### PR TITLE
Add create beta tester

### DIFF
--- a/lib/app_store_connect.rb
+++ b/lib/app_store_connect.rb
@@ -13,6 +13,7 @@ require 'app_store_connect/certificate_create_request'
 require 'app_store_connect/device_create_request'
 require 'app_store_connect/user_invitation_create_request'
 require 'app_store_connect/profile_create_request'
+require 'app_store_connect/beta_testers_create_request'
 
 module AppStoreConnect
   @config = {}

--- a/lib/app_store_connect.rb
+++ b/lib/app_store_connect.rb
@@ -13,7 +13,7 @@ require 'app_store_connect/certificate_create_request'
 require 'app_store_connect/device_create_request'
 require 'app_store_connect/user_invitation_create_request'
 require 'app_store_connect/profile_create_request'
-require 'app_store_connect/beta_testers_create_request'
+require 'app_store_connect/beta_tester_create_request'
 
 module AppStoreConnect
   @config = {}

--- a/lib/app_store_connect/beta_tester_create_request.rb
+++ b/lib/app_store_connect/beta_tester_create_request.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'app_store_connect/create_request'
+
+module AppStoreConnect
+  class BetaTesterCreateRequest < CreateRequest
+    data do
+      type 'betaTesters'
+
+      attributes do
+        property :first_name, required: true
+        property :last_name, required: true
+        property :email, required: true
+      end
+    end
+  end
+end

--- a/lib/config/schema.json
+++ b/lib/config/schema.json
@@ -135,6 +135,7 @@
 		{
 			"alias": "create_beta_tester",
 			"url": "https://api.appstoreconnect.apple.com/v1/betaTesters",
+			"http_body_type": "BetaTesterCreateRequest",
 			"http_method": "post"
 		},
 		{

--- a/lib/config/schema.json
+++ b/lib/config/schema.json
@@ -1,6 +1,6 @@
 {
-  "objects": [],
-   "web_service_endpoints": [
+	"objects": [],
+	"web_service_endpoints": [
 		{
 			"http_method": "delete",
 			"url": "https://api.appstoreconnect.apple.com/v1/users/{id}",
@@ -115,7 +115,7 @@
 			"http_body_type": "DeviceCreateRequest"
 		},
 		{
-			"alias": "create_user_invitation", 
+			"alias": "create_user_invitation",
 			"url": "https://api.appstoreconnect.apple.com/v1/userInvitations",
 			"http_body_type": "UserInvitationCreateRequest",
 			"http_method": "post"
@@ -133,609 +133,614 @@
 			"http_method": "post"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/users",
-		"alias": "users"
+			"alias": "create_beta_tester",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaTesters",
+			"http_method": "post"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/users/{id}",
-		"alias": "user"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/users",
+			"alias": "users"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/users/{id}/visibleApps",
-		"alias": "user_visible_apps"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/users/{id}",
+			"alias": "user"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/users/{id}/relationships/visibleApps",
-		"alias": "user_relationships_visible_apps"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/users/{id}/visibleApps",
+			"alias": "user_visible_apps"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/userInvitations/{id}",
-		"alias": "user_invitation"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/users/{id}/relationships/visibleApps",
+			"alias": "user_relationships_visible_apps"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/userInvitations",
-		"alias": "user_invitations"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/userInvitations/{id}",
+			"alias": "user_invitation"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/userInvitations/{id}/visibleApps",
-		"alias": "user_invitation_visible_apps"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/userInvitations",
+			"alias": "user_invitations"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/userInvitations/{id}/relationships/visibleApps",
-		"alias": "user_invitation_relationships_visible_apps"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/userInvitations/{id}/visibleApps",
+			"alias": "user_invitation_visible_apps"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/bundleIds/{id}",
-		"alias": "bundle_id"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/userInvitations/{id}/relationships/visibleApps",
+			"alias": "user_invitation_relationships_visible_apps"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/bundleIds",
-		"alias": "bundle_ids"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/bundleIds/{id}",
+			"alias": "bundle_id"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/bundleIds/{id}/relationships/profiles",
-		"alias": "bundle_id_relationships_profiles"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/bundleIds",
+			"alias": "bundle_ids"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/bundleIds/{id}/bundleIdCapabilities",
-		"alias": "bundle_id_bundle_id_capabilities"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/bundleIds/{id}/relationships/profiles",
+			"alias": "bundle_id_relationships_profiles"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/bundleIds/{id}/profiles",
-		"alias": "bundle_id_profiles"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/bundleIds/{id}/bundleIdCapabilities",
+			"alias": "bundle_id_bundle_id_capabilities"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/bundleIds/{id}/relationships/bundleIdCapabilities",
-		"alias": "bundle_id_relationships_bundle_id_capabilities"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/bundleIds/{id}/profiles",
+			"alias": "bundle_id_profiles"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/certificates",
-		"alias": "certificates"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/bundleIds/{id}/relationships/bundleIdCapabilities",
+			"alias": "bundle_id_relationships_bundle_id_capabilities"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/certificates/{id}",
-		"alias": "certificate"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/certificates",
+			"alias": "certificates"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/devices",
-		"alias": "devices"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/certificates/{id}",
+			"alias": "certificate"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/devices/{id}",
-		"alias": "device"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/devices",
+			"alias": "devices"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/financeReports",
-		"alias": "financial_reports"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/devices/{id}",
+			"alias": "device"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/salesReports",
-		"alias": "sales_reports"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/financeReports",
+			"alias": "financial_reports"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/profiles",
-		"alias": "profiles"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/salesReports",
+			"alias": "sales_reports"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/profiles/{id}",
-		"alias": "profile"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/profiles",
+			"alias": "profiles"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/profiles/{id}/bundleId",
-		"alias": "profile_bundle_id"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/profiles/{id}",
+			"alias": "profile"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/profiles/{id}/relationships/bundleId",
-		"alias": "profile_relationships_bundle_id"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/profiles/{id}/bundleId",
+			"alias": "profile_bundle_id"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/profiles/{id}/relationships/certificates",
-		"alias": "profile_relationships_certificates"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/profiles/{id}/relationships/bundleId",
+			"alias": "profile_relationships_bundle_id"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/profiles/{id}/devices",
-		"alias": "profile_devices"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/profiles/{id}/relationships/certificates",
+			"alias": "profile_relationships_certificates"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/profiles/{id}/certificates",
-		"alias": "profile_certificates"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/profiles/{id}/devices",
+			"alias": "profile_devices"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/profiles/{id}/relationships/devices",
-		"alias": "profile_relationships_devices"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/profiles/{id}/certificates",
+			"alias": "profile_certificates"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaTesters",
-		"alias": "beta_testers"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/profiles/{id}/relationships/devices",
+			"alias": "profile_relationships_devices"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaTesters/{id}",
-		"alias": "beta_tester"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaTesters",
+			"alias": "beta_testers"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaTesters/{id}/apps",
-		"alias": "beta_tester_apps"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaTesters/{id}",
+			"alias": "beta_tester"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaTesters/{id}/builds",
-		"alias": "beta_tester_builds"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaTesters/{id}/apps",
+			"alias": "beta_tester_apps"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaTesters/{id}/relationships/builds",
-		"alias": "beta_tester_relationships_builds"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaTesters/{id}/builds",
+			"alias": "beta_tester_builds"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaTesters/{id}/relationships/apps",
-		"alias": "beta_tester_relationships_apps"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaTesters/{id}/relationships/builds",
+			"alias": "beta_tester_relationships_builds"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaTesters/{id}/betaGroups",
-		"alias": "beta_tester_beta_groups"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaTesters/{id}/relationships/apps",
+			"alias": "beta_tester_relationships_apps"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaTesters/{id}/relationships/betaGroups",
-		"alias": "beta_tester_relationships_beta_groups"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaTesters/{id}/betaGroups",
+			"alias": "beta_tester_beta_groups"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/apps",
-		"alias": "apps"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaTesters/{id}/relationships/betaGroups",
+			"alias": "beta_tester_relationships_beta_groups"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}",
-		"alias": "app"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/apps",
+			"alias": "apps"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/betaGroups",
-		"alias": "app_beta_groups"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}",
+			"alias": "app"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/relationships/betaGroups",
-		"alias": "app_relationships_beta_groups"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/betaGroups",
+			"alias": "app_beta_groups"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/builds",
-		"alias": "app_builds"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/relationships/betaGroups",
+			"alias": "app_relationships_beta_groups"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/relationships/builds",
-		"alias": "app_relationships_builds"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/builds",
+			"alias": "app_builds"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/preReleaseVersions",
-		"alias": "app_pre_release_versions"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/relationships/builds",
+			"alias": "app_relationships_builds"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/relationships/preReleaseVersions",
-		"alias": "app_relationships_pre_release_versions"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/preReleaseVersions",
+			"alias": "app_pre_release_versions"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/betaAppReviewDetail",
-		"alias": "app_beta_app_review_detail"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/relationships/preReleaseVersions",
+			"alias": "app_relationships_pre_release_versions"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/betaLicenseAgreement",
-		"alias": "app_beta_license_agreement"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/betaAppReviewDetail",
+			"alias": "app_beta_app_review_detail"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/betaAppLocalizations",
-		"alias": "app_beta_app_localizations"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/betaLicenseAgreement",
+			"alias": "app_beta_license_agreement"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/relationships/betaAppReviewDetail",
-		"alias": "app_relationships_beta_app_review_detail"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/betaAppLocalizations",
+			"alias": "app_beta_app_localizations"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/relationships/betaLicenseAgreement",
-		"alias": "app_relationships_beta_license_agreement"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/relationships/betaAppReviewDetail",
+			"alias": "app_relationships_beta_app_review_detail"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/relationships/betaAppLocalizations",
-		"alias": "app_relationships_beta_app_localizations"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/relationships/betaLicenseAgreement",
+			"alias": "app_relationships_beta_license_agreement"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/preReleaseVersions",
-		"alias": "pre_release_versions"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/relationships/betaAppLocalizations",
+			"alias": "app_relationships_beta_app_localizations"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/{id}",
-		"alias": "pre_release_version"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/preReleaseVersions",
+			"alias": "pre_release_versions"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/{id}/relationships/app",
-		"alias": "pre_release_version_relationships_app"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/{id}",
+			"alias": "pre_release_version"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/{id}/builds",
-		"alias": "pre_release_version_builds"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/{id}/relationships/app",
+			"alias": "pre_release_version_relationships_app"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/{id}/app",
-		"alias": "pre_release_version_app"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/{id}/builds",
+			"alias": "pre_release_version_builds"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/{id}/relationships/builds",
-		"alias": "pre_release_version_relationships_builds"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/{id}/app",
+			"alias": "pre_release_version_app"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaGroups",
-		"alias": "beta_groups"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/preReleaseVersions/{id}/relationships/builds",
+			"alias": "pre_release_version_relationships_builds"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaGroups/{id}",
-		"alias": "beta_group"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaGroups",
+			"alias": "beta_groups"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaGroups/{id}/app",
-		"alias": "beta_group_apps"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaGroups/{id}",
+			"alias": "beta_group"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaGroups/{id}/relationships/app",
-		"alias": "beta_group_relationships_app"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaGroups/{id}/app",
+			"alias": "beta_group_apps"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaGroups/{id}/betaTesters",
-		"alias": "beta_group_beta_testers"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaGroups/{id}/relationships/app",
+			"alias": "beta_group_relationships_app"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaGroups/{id}/relationships/builds",
-		"alias": "beta_group_relationships_builds"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaGroups/{id}/betaTesters",
+			"alias": "beta_group_beta_testers"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaGroups/{id}/relationships/betaTesters",
-		"alias": "beta_group_relationships_beta_testers"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaGroups/{id}/relationships/builds",
+			"alias": "beta_group_relationships_builds"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/builds",
-		"alias": "builds"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaGroups/{id}/relationships/betaTesters",
+			"alias": "beta_group_relationships_beta_testers"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}",
-		"alias": "build"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/builds",
+			"alias": "builds"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/app",
-		"alias": "build_app"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}",
+			"alias": "build"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaGroups/{id}/builds",
-		"alias": "beta_group_builds"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/app",
+			"alias": "build_app"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/preReleaseVersion",
-		"alias": "build_pre_release_version"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaGroups/{id}/builds",
+			"alias": "beta_group_builds"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/relationships/preReleaseVersion",
-		"alias": "build_relationships_pre_release_version"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/preReleaseVersion",
+			"alias": "build_pre_release_version"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/relationships/app",
-		"alias": "build_relationships_app"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/relationships/preReleaseVersion",
+			"alias": "build_relationships_pre_release_version"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/individualTesters",
-		"alias": "build_individual_testers"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/relationships/app",
+			"alias": "build_relationships_app"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/relationships/betaAppReviewSubmission",
-		"alias": "build_relationships_beta_app_review_submission"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/individualTesters",
+			"alias": "build_individual_testers"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/relationships/individualTesters",
-		"alias": "build_relationships_individual_testers"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/relationships/betaAppReviewSubmission",
+			"alias": "build_relationships_beta_app_review_submission"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/buildBetaDetail",
-		"alias": "build_build_beta_detail"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/relationships/individualTesters",
+			"alias": "build_relationships_individual_testers"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/relationships/buildBetaDetail",
-		"alias": "build_relationships_build_beta_detail"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/buildBetaDetail",
+			"alias": "build_build_beta_detail"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/betaAppReviewSubmission",
-		"alias": "build_beta_app_review_submission"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/relationships/buildBetaDetail",
+			"alias": "build_relationships_build_beta_detail"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/relationships/appEncryptionDeclaration",
-		"alias": "build_relationships_app_encryption_declaration"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/betaAppReviewSubmission",
+			"alias": "build_beta_app_review_submission"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/betaBuildLocalizations",
-		"alias": "build_beta_build_localizations"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/relationships/appEncryptionDeclaration",
+			"alias": "build_relationships_app_encryption_declaration"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/relationships/betaBuildLocalizations",
-		"alias": "build_relationships_beta_build_localizations"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/betaBuildLocalizations",
+			"alias": "build_beta_build_localizations"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/appEncryptionDeclaration",
-		"alias": "build_app_encryption_declaration"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/relationships/betaBuildLocalizations",
+			"alias": "build_relationships_beta_build_localizations"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/appEncryptionDeclarations",
-		"alias": "app_encryption_declarations"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/builds/{id}/appEncryptionDeclaration",
+			"alias": "build_app_encryption_declaration"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/appEncryptionDeclarations/{id}",
-		"alias": "app_encryption_declaration"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/appEncryptionDeclarations",
+			"alias": "app_encryption_declarations"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/appEncryptionDeclarations/{id}/app",
-		"alias": "app_encryption_declaration_app"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/appEncryptionDeclarations/{id}",
+			"alias": "app_encryption_declaration"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/appEncryptionDeclarations/{id}/relationships/app",
-		"alias": "app_encryption_declaration_relationships_app"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/appEncryptionDeclarations/{id}/app",
+			"alias": "app_encryption_declaration_app"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/buildBetaDetails",
-		"alias": "build_beta_details"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/appEncryptionDeclarations/{id}/relationships/app",
+			"alias": "app_encryption_declaration_relationships_app"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/buildBetaDetails/{id}",
-		"alias": "build_beta_detail"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/buildBetaDetails",
+			"alias": "build_beta_details"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/buildBetaDetails/{id}/build",
-		"alias": "build_beta_detail_build"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/buildBetaDetails/{id}",
+			"alias": "build_beta_detail"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/buildBetaDetails/{id}/relationships/build",
-		"alias": "build_beta_detail_relationships_build"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/buildBetaDetails/{id}/build",
+			"alias": "build_beta_detail_build"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaAppLocalizations",
-		"alias": "beta_app_localizations"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/buildBetaDetails/{id}/relationships/build",
+			"alias": "build_beta_detail_relationships_build"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaAppLocalizations/{id}/app",
-		"alias": "beta_app_localization_app"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaAppLocalizations",
+			"alias": "beta_app_localizations"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaAppLocalizations/{id}",
-		"alias": "beta_app_localization"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaAppLocalizations/{id}/app",
+			"alias": "beta_app_localization_app"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaAppLocalizations/{id}/relationships/app",
-		"alias": "beta_app_localization_relationships_app"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaAppLocalizations/{id}",
+			"alias": "beta_app_localization"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaLicenseAgreements",
-		"alias": "beta_license_agreements"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaAppLocalizations/{id}/relationships/app",
+			"alias": "beta_app_localization_relationships_app"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaLicenseAgreements/{id}/relationships/app",
-		"alias": "beta_license_agreement_relationships_app"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaLicenseAgreements",
+			"alias": "beta_license_agreements"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaLicenseAgreements/{id}/app",
-		"alias": "beta_license_agreement_app"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaLicenseAgreements/{id}/relationships/app",
+			"alias": "beta_license_agreement_relationships_app"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaLicenseAgreements/{id}",
-		"alias": "beta_license_agreement"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaLicenseAgreements/{id}/app",
+			"alias": "beta_license_agreement_app"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaBuildLocalizations/{id}/relationships/build",
-		"alias": "beta_build_localization_relationships_build"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaLicenseAgreements/{id}",
+			"alias": "beta_license_agreement"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaBuildLocalizations/{id}/build",
-		"alias": "beta_build_localization_build"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaBuildLocalizations/{id}/relationships/build",
+			"alias": "beta_build_localization_relationships_build"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaBuildLocalizations",
-		"alias": "beta_build_localizations"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaBuildLocalizations/{id}/build",
+			"alias": "beta_build_localization_build"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaBuildLocalizations/{id}",
-		"alias": "beta_build_localization"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaBuildLocalizations",
+			"alias": "beta_build_localizations"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaAppReviewDetails",
-		"alias": "beta_app_review_details"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaBuildLocalizations/{id}",
+			"alias": "beta_build_localization"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaAppReviewDetails/{id}",
-		"alias": "beta_app_review_detail"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaAppReviewDetails",
+			"alias": "beta_app_review_details"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaAppReviewDetails/{id}/relationships/app",
-		"alias": "beta_app_review_detail_relationships_app"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaAppReviewDetails/{id}",
+			"alias": "beta_app_review_detail"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaAppReviewDetails/{id}/app",
-		"alias": "beta_app_review_detail_app"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaAppReviewDetails/{id}/relationships/app",
+			"alias": "beta_app_review_detail_relationships_app"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaAppReviewSubmissions",
-		"alias": "beta_app_review_submissions"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaAppReviewDetails/{id}/app",
+			"alias": "beta_app_review_detail_app"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaAppReviewSubmissions/{id}",
-		"alias": "beta_app_review_submission"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaAppReviewSubmissions",
+			"alias": "beta_app_review_submissions"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaAppReviewSubmissions/{id}/relationships/build",
-		"alias": "beta_app_review_submission_relationships_build"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaAppReviewSubmissions/{id}",
+			"alias": "beta_app_review_submission"
 		},
 		{
-		"http_method": "get",
-		"url": "https://api.appstoreconnect.apple.com/v1/betaAppReviewSubmissions/{id}/build",
-		"alias": "beta_app_review_submission_build"
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaAppReviewSubmissions/{id}/relationships/build",
+			"alias": "beta_app_review_submission_relationships_build"
+		},
+		{
+			"http_method": "get",
+			"url": "https://api.appstoreconnect.apple.com/v1/betaAppReviewSubmissions/{id}/build",
+			"alias": "beta_app_review_submission_build"
 		}
-  ],
-  "types": [
-    {
-    "type": "CapabilityType",
-    "values": [
-      "ICLOUD",
-      "IN_APP_PURCHASE",
-      "GAME_CENTER",
-      "PUSH_NOTIFICATIONS",
-      "WALLET",
-      "INTER_APP_AUDIO",
-      "MAPS",
-      "ASSOCIATED_DOMAINS",
-      "PERSONAL_VPN",
-      "APP_GROUPS",
-      "HEALTHKIT",
-      "HOMEKIT",
-      "WIRELESS_ACCESSORY_CONFIGURATION",
-      "APPLE_PAY",
-      "DATA_PROTECTION",
-      "SIRIKIT",
-      "NETWORK_EXTENSIONS",
-      "MULTIPATH",
-      "HOT_SPOT",
-      "NFC_TAG_READING",
-      "CLASSKIT",
-      "AUTOFILL_CREDENTIAL_PROVIDER",
-      "ACCESS_WIFI_INFORMATION"
-      ]
-    },
-    {
-      "type": "CertificateType",
-      "values": [
-        "OS_DEVELOPMENT",
-        "IOS_DISTRIBUTION",
-        "MAC_APP_DISTRIBUTION",
-        "MAC_INSTALLER_DISTRIBUTION",
-        "MAC_APP_DEVELOPMENT",
-        "DEVELOPER_ID_KEXT",
-        "DEVELOPER_ID_APPLICATION"
-      ]
-    },
-    {
-      "type": "BundleIdPlatform",
-      "values": [
-        "IOS", 
-        "MAC_OS"
-      ]
-    },
-    {
-      "type": "UserRole",
-      "values": [
-        "ADMIN",
-        "FINANCE",
-        "TECHNICAL",
-        "SALES",
-        "MARKETING", 
-        "DEVELOPER",
-        "ACCOUNT_HOLDER",
-        "READ_ONLY", 
-        "APP_MANAGER",
-        "ACCESS_TO_REPORTS",
-        "CUSTOMER_REPORTS"
-      ]
-    } 
-  ]
+	],
+	"types": [
+		{
+			"type": "CapabilityType",
+			"values": [
+				"ICLOUD",
+				"IN_APP_PURCHASE",
+				"GAME_CENTER",
+				"PUSH_NOTIFICATIONS",
+				"WALLET",
+				"INTER_APP_AUDIO",
+				"MAPS",
+				"ASSOCIATED_DOMAINS",
+				"PERSONAL_VPN",
+				"APP_GROUPS",
+				"HEALTHKIT",
+				"HOMEKIT",
+				"WIRELESS_ACCESSORY_CONFIGURATION",
+				"APPLE_PAY",
+				"DATA_PROTECTION",
+				"SIRIKIT",
+				"NETWORK_EXTENSIONS",
+				"MULTIPATH",
+				"HOT_SPOT",
+				"NFC_TAG_READING",
+				"CLASSKIT",
+				"AUTOFILL_CREDENTIAL_PROVIDER",
+				"ACCESS_WIFI_INFORMATION"
+			]
+		},
+		{
+			"type": "CertificateType",
+			"values": [
+				"OS_DEVELOPMENT",
+				"IOS_DISTRIBUTION",
+				"MAC_APP_DISTRIBUTION",
+				"MAC_INSTALLER_DISTRIBUTION",
+				"MAC_APP_DEVELOPMENT",
+				"DEVELOPER_ID_KEXT",
+				"DEVELOPER_ID_APPLICATION"
+			]
+		},
+		{
+			"type": "BundleIdPlatform",
+			"values": [
+				"IOS",
+				"MAC_OS"
+			]
+		},
+		{
+			"type": "UserRole",
+			"values": [
+				"ADMIN",
+				"FINANCE",
+				"TECHNICAL",
+				"SALES",
+				"MARKETING",
+				"DEVELOPER",
+				"ACCOUNT_HOLDER",
+				"READ_ONLY",
+				"APP_MANAGER",
+				"ACCESS_TO_REPORTS",
+				"CUSTOMER_REPORTS"
+			]
+		}
+	]
 }


### PR DESCRIPTION
Support creation of a beta tester using the create_beta_tester alias
When creating a BetaTester, requires the betaGroup to be specified as a relationship e.g.
```
client.create_beta_tester(
  first_name: "Billy",
  last_name: "Testerson"
  email: "billytest@example.com",
  relationships: {"betaGroups": {"data": [{id: "xxx-xxx-xxx-xxx", type: "betaGroups"}]}}
)
```